### PR TITLE
BAL kernel module - support for RC663 and PN512

### DIFF
--- a/bal/Makefile
+++ b/bal/Makefile
@@ -4,3 +4,4 @@
 
 obj-m					+= bal.o
 ccflags-y := -I$(src)/include
+EXTRA_CFLAGS += -Wno-error=date-time

--- a/bal/bal.c
+++ b/bal/bal.c
@@ -51,7 +51,7 @@ struct bal_data {
 	bool			in_use;
 	unsigned int		busy_pin;
 	u8	*		buffer;
-	u8	*		rxBuffer;
+	//u8	*		rxBuffer;
 	unsigned long		HalType;
 	unsigned long		MultiRegRW;
 };
@@ -103,18 +103,18 @@ baldev_read(struct file *filp, char __user *buf, size_t count, loff_t *f_pos)
 		  status = copy_from_user(bal.buffer, buf, count);
 	
 		  xfers.tx_buf = bal.buffer;
-		  xfers.rx_buf = bal.rxBuffer;
+		  xfers.rx_buf = bal.buffer;//rxBuffer;
 		  xfers.len = count;
 
-		  //xfers.rx_dma = bal.buffer;
-		  //xfers.rx_dma = bal.rxBuffer;
+		  //xfers.tx_dma = bal.buffer;
+		  //xfers.rx_dma = bal.buffer;//rxBuffer;
 
 		  xfers.tx_nbits = SPI_NBITS_SINGLE;
 		  xfers.rx_nbits = SPI_NBITS_SINGLE;
 
 		  xfers.bits_per_word = 8;
 		  xfers.delay_usecs = 0;
-		  xfers.speed_hz = bal.spi->max_speed_hz;
+		  xfers.speed_hz = 3e6;//bal.spi->max_speed_hz;
 
 		  //printk(KERN_ERR "master flags = %04X\n", bal.spi->master->flags);
 		  //printk(KERN_ERR "speed_hz = %d Hz\n", xfers.speed_hz);
@@ -145,7 +145,7 @@ baldev_read(struct file *filp, char __user *buf, size_t count, loff_t *f_pos)
 		//	printk(KERN_ERR "after READ rxBuffer[%d] = %d", i, bal.rxBuffer[i]);
 		//}
 
-		if (copy_to_user(buf, bal.rxBuffer, count))
+		if (copy_to_user(buf, bal.buffer/*rxBuffer*/, count))
 			return -EFAULT;	
 	}
 		
@@ -201,12 +201,12 @@ static int baldev_open(struct inode *inode, struct file *filp)
 		mutex_unlock(&bal.use_lock);
 		return -ENOMEM;
 	}
-	bal.rxBuffer = (uint8_t *)kmalloc(BAL_MAX_BUF_SIZE, GFP_KERNEL | GFP_DMA);
-	if (bal.rxBuffer == NULL) {
-		dev_err(&bal.spi->dev, "Unable to alloc memory!\n");
-		mutex_unlock(&bal.use_lock);
-		return -ENOMEM;
-	}
+	//bal.rxBuffer = (uint8_t *)kmalloc(BAL_MAX_BUF_SIZE, GFP_KERNEL | GFP_DMA);
+	//if (bal.rxBuffer == NULL) {
+	//	dev_err(&bal.spi->dev, "Unable to alloc memory!\n");
+	//	mutex_unlock(&bal.use_lock);
+	//	return -ENOMEM;
+	//}
 
 	bal.in_use = true;
 	mutex_unlock(&bal.use_lock);

--- a/bal/bal.c
+++ b/bal/bal.c
@@ -251,6 +251,9 @@ baldev_read(struct file *filp, char __user *buf, size_t count, loff_t *f_pos)
 			status = spi_read(bal.spi, bal.buffer, count);
 			printk(KERN_ERR "READ");
 		}
+
+		if (copy_to_user(buf, bal.buffer, count))
+			return -EFAULT;	
 	}
 	else
 	{
@@ -306,12 +309,11 @@ baldev_read(struct file *filp, char __user *buf, size_t count, loff_t *f_pos)
 		//	printk(KERN_ERR "after READ buffer[%d] = %d", i, bal.buffer[i]);
 		//	printk(KERN_ERR "after READ rxBuffer[%d] = %d", i, bal.rxBuffer[i]);
 		//}
-	
-	}
 
-	if (copy_to_user(buf, bal.rxBuffer, count))
-		return -EFAULT;
-	
+		if (copy_to_user(buf, bal.rxBuffer, count))
+			return -EFAULT;	
+	}
+		
 	return count;
 }
 
@@ -333,6 +335,8 @@ baldev_write(struct file *filp, const char __user *buf,
 
 	if(bal.HalType == 2)
 	{
+		status = wait_for_busy_idle();
+		
 		if (0 == status) {
 
 			if (status == 0) {

--- a/bal/bal.c
+++ b/bal/bal.c
@@ -84,7 +84,7 @@ baldev_read(struct file *filp, char __user *buf, size_t count, loff_t *f_pos)
 
 	int i;
 
-	printk(KERN_ERR "READ MultiReg - count: %d\n", count);
+	//printk(KERN_ERR "READ MultiReg - count: %d\n", count);
 
 	if(bal.HalType == 0x02)
 	{
@@ -115,10 +115,11 @@ baldev_read(struct file *filp, char __user *buf, size_t count, loff_t *f_pos)
 		if( count < 1 )
 			return count;
 		
-	    if( ((bal.HalType == 1/*PHBAL_REG_HAL_HW_RC663*/) && ( (bal.buffer[0] & 0x01) == 0x01 ))
-	    	||  ((bal.HalType == 0/*PHBAL_REG_HAL_HW_RC523*/) && ( (bal.buffer[0] & 0x80) == 0x80 )) )
+	    //if( ((bal.HalType == 1/*PHBAL_REG_HAL_HW_RC663*/) && ( (bal.buffer[0] & 0x01) == 0x01 ))
+	    //	||  ((bal.HalType == 0/*PHBAL_REG_HAL_HW_RC523*/) && ( (bal.buffer[0] & 0x80) == 0x80 )) )
+		if(bal.MultiRegRW == 1)
 	    {
-	    	printk(KERN_ERR "READ MultiReg\n");
+	    	printk(KERN_ERR "READ MultiReg - %d\n", bal.MultiRegRW);
 			
 			//Perform a "MultiRegRead" exchange
 	    	//This is a read operation
@@ -126,24 +127,17 @@ baldev_read(struct file *filp, char __user *buf, size_t count, loff_t *f_pos)
 			if(status){
 				printk(KERN_ERR "Multi reg read status = %d = %04X\n", status, status);
 				return status;
-			}			
+			}
+
+			for(i = 0; i < count; i++) {
+				printk(KERN_ERR "after READ buffer[%d] = %d", i, bal.buffer[i]);
+				//printk(KERN_ERR "after READ rxBuffer[%d] = %d", i, bal.buffer[i]);
+			}
 			//return count;
 	    }
 		else
 		{
-			printk(KERN_ERR "READ\n");
-
-			//for(i = 0; i < count; i++) {
-			//	printk(KERN_ERR "before READ buffer[%d] = %d", i, bal.buffer[i]);
-			//	printk(KERN_ERR "before READ rxBuffer[%d] = %d", i, bal.rxBuffer[i]);
-			//}
-		
-			//for(i = 0; i < count; i++)
-			//{
-			//	result = spi_w8r8(bal.spi, bal.buffer[i]);						
-			//	bal.buffer[i] = (uint8_t)result;
-			//}
-			//bal.buffer[0] = 0x00; // reader expets the first byte in the reply buffer 00h
+			//printk(KERN_ERR "normal READ\n");
 
 			status = spi_sync_transfer(bal.spi, &(bal.xfers), 1);
 
@@ -151,11 +145,6 @@ baldev_read(struct file *filp, char __user *buf, size_t count, loff_t *f_pos)
 				printk(KERN_ERR "status = %d = %04X\n", status, status);
 				return status;
 			}			
-		}
-
-		for(i = 0; i < count; i++) {
-				printk(KERN_ERR "after READ buffer[%d] = %d", i, bal.buffer[i]);
-				//printk(KERN_ERR "after READ rxBuffer[%d] = %d", i, bal.buffer[i]);
 		}
 
 		if (copy_to_user(buf, bal.buffer/*rxBuffer*/, count))
@@ -296,7 +285,7 @@ baldev_ioctl(struct file *filp, unsigned int cmd, unsigned long arg)
 	//
 	//}
 	
-	dev_info(&bal.spi->dev, "%s : %d fp=%ld cmd=%ld arg=%lx\n", __FUNCTION__, __LINE__, (unsigned long int)filp, cmd, arg);
+	//dev_info(&bal.spi->dev, "%s : %d fp=%ld cmd=%ld arg=%lx\n", __FUNCTION__, __LINE__, (unsigned long int)filp, cmd, arg);
 	
 	switch (cmd) {
 		case BAL_IOC_BUSY_PIN:
@@ -322,13 +311,13 @@ baldev_ioctl(struct file *filp, unsigned int cmd, unsigned long arg)
 		case BAL_IOC_HAL_HW_TYPE:
 			bal.HalType = arg;
 			status = 0;
-			dev_info(&bal.spi->dev, "BAL_IOC_HAL_HW_TYPE - %d - %d\n", cmd, (unsigned int)arg);
+			//dev_info(&bal.spi->dev, "BAL_IOC_HAL_HW_TYPE - %d - %d\n", cmd, (unsigned int)arg);
 			printk(KERN_INFO "HAL_HW_type %s - %d %u\n", __FUNCTION__, __LINE__, arg);
 			break;
 		case BAL_IOC_RW_MULTI_REG:
 			bal.MultiRegRW = arg;
 			status = 0;
-			dev_info(&bal.spi->dev, "BAL_IOC_RW_MULTI_REG - %d - %d\n", cmd, (unsigned int)arg);
+			//dev_info(&bal.spi->dev, "BAL_IOC_RW_MULTI_REG - %d - %d\n", cmd, (unsigned int)arg);
 			printk(KERN_INFO "multiREG %s - %d  %u\n", __FUNCTION__, __LINE__, arg);
 			break;
 		default:

--- a/bal/bal.c
+++ b/bal/bal.c
@@ -237,40 +237,8 @@ baldev_read(struct file *filp, char __user *buf, size_t count, loff_t *f_pos)
 	ssize_t			status = 0;
 
 	int i;
-	ssize_t result;
 	struct spi_transfer xfers;
 		
-	if (count > BAL_MAX_BUF_SIZE)
-		return -EMSGSIZE;
-	status = copy_from_user(bal.buffer, buf, count);
-	
-  //	struct spi_transfer {
-  xfers.tx_buf = bal.buffer;
-  xfers.rx_buf = bal.rxBuffer;
-  xfers.len = count;
-
-  xfers.rx_dma = bal.buffer;
-  xfers.rx_dma = bal.rxBuffer;
-  //struct sg_table tx_sg;
-  //struct sg_table rx_sg;
-
-  xfers.tx_nbits = SPI_NBITS_SINGLE;
-  xfers.rx_nbits = SPI_NBITS_SINGLE;
-
-  xfers.bits_per_word = 8;
-  xfers.delay_usecs = 0;
-  xfers.speed_hz = bal.spi->max_speed_hz;
-  //struct list_head transfer_list;
-//}; 
-
-  uint16_t flags = bal.spi->master->flags;
-  //printk(KERN_ERR "master flags = %04X\n", bal.spi->master->flags);
-  //printk(KERN_ERR "mode flags = %04X\n", bal.spi->mode);
-  printk(KERN_ERR "speed_hz = %d Hz\n", xfers.speed_hz);
-  
-  printk(KERN_ERR "speed_hz spidev= %d Hz\n", bal.spi->max_speed_hz);
-
-
   //status = __spi_validate(bal.spi, &xfers);
   //printk(KERN_ERR "status = %d\n", status);
 
@@ -286,6 +254,34 @@ baldev_read(struct file *filp, char __user *buf, size_t count, loff_t *f_pos)
 	}
 	else
 	{
+		  if (count > BAL_MAX_BUF_SIZE)
+			return -EMSGSIZE;
+		
+		  status = copy_from_user(bal.buffer, buf, count);
+	
+		  xfers.tx_buf = bal.buffer;
+		  xfers.rx_buf = bal.rxBuffer;
+		  xfers.len = count;
+
+		  xfers.rx_dma = bal.buffer;
+		  xfers.rx_dma = bal.rxBuffer;
+		  //struct sg_table tx_sg;
+		  //struct sg_table rx_sg;
+
+		  xfers.tx_nbits = SPI_NBITS_SINGLE;
+		  xfers.rx_nbits = SPI_NBITS_SINGLE;
+
+		  xfers.bits_per_word = 8;
+		  xfers.delay_usecs = 0;
+		  xfers.speed_hz = bal.spi->max_speed_hz;
+
+		  //printk(KERN_ERR "master flags = %04X\n", bal.spi->master->flags);
+		  //printk(KERN_ERR "mode flags = %04X\n", bal.spi->mode);
+		  printk(KERN_ERR "speed_hz = %d Hz\n", xfers.speed_hz);
+  
+		  printk(KERN_ERR "speed_hz spidev= %d Hz\n", bal.spi->max_speed_hz);
+
+
 		//for(i = 0; i < count; i++) {
 		//	printk(KERN_ERR "before READ buffer[%d] = %d", i, bal.buffer[i]);
 		//	printk(KERN_ERR "before READ rxBuffer[%d] = %d", i, bal.rxBuffer[i]);
@@ -311,15 +307,11 @@ baldev_read(struct file *filp, char __user *buf, size_t count, loff_t *f_pos)
 		//	printk(KERN_ERR "after READ rxBuffer[%d] = %d", i, bal.rxBuffer[i]);
 		//}
 	
-		result = 0;
-	//if (copy_to_user(buf, &result, 1))
-	//	return -EFAULT;
-	//if (copy_to_user(buf+1, bal.buffer, count-1))
-	//	return -EFAULT;
+	}
+
 	if (copy_to_user(buf, bal.rxBuffer, count))
 		return -EFAULT;
 	
-	}
 	return count;
 }
 
@@ -337,13 +329,16 @@ baldev_write(struct file *filp, const char __user *buf,
 		return status;
 	}
 
-	printk(KERN_ERR "WR filp=%d   buf=%02X,%02X  count=%d\n", filp, buf[0], buf[1], count);
+	//printk(KERN_ERR "WR filp=%d   buf=%02X,%02X  count=%d\n", filp, buf[0], buf[1], count);
 
 	if(bal.HalType == 2)
 	{
-		status = wait_for_busy_idle();
-		if (status == 0)
+		if (0 == status) {
+
+			if (status == 0) {
 				status = spi_write(bal.spi, bal.buffer, count);
+			}
+		}
 	}
 	else
 		status = spi_write(bal.spi, bal.buffer, count);

--- a/bal/bal.c
+++ b/bal/bal.c
@@ -114,7 +114,7 @@ baldev_read(struct file *filp, char __user *buf, size_t count, loff_t *f_pos)
 
 		  xfers.bits_per_word = 8;
 		  xfers.delay_usecs = 0;
-		  xfers.speed_hz = 3e6;//bal.spi->max_speed_hz;
+		  xfers.speed_hz = bal.spi->max_speed_hz;
 
 		  //printk(KERN_ERR "master flags = %04X\n", bal.spi->master->flags);
 		  //printk(KERN_ERR "speed_hz = %d Hz\n", xfers.speed_hz);
@@ -168,14 +168,15 @@ baldev_write(struct file *filp, const char __user *buf,
 
 	if(bal.HalType == 2)
 	{
+		//printk(KERN_ERR "WAS HERE!!! count: %d,  data: %02X-%02X-%02X ", count, bal.buffer[0], bal.buffer[1], bal.buffer[2]);
 		status = wait_for_busy_idle();
 		
-		if (0 == status) {
+		//if (0 == status) {
 
 			if (status == 0) {
 				status = spi_write(bal.spi, bal.buffer, count);
 			}
-		}
+		//}
 	}
 	else
 		status = spi_write(bal.spi, bal.buffer, count);

--- a/bal/bal.c
+++ b/bal/bal.c
@@ -41,6 +41,10 @@
 #define BAL_IOC_HAL_HW_TYPE		3
 #define BAL_IOC_RW_MULTI_REG		4
 
+#define BAL_HAL_HW_RC523		0
+#define BAL_HAL_HW_RC663		1
+#define BAL_HAL_HW_PN5180		2
+
 struct bal_data {
 	dev_t			devt;
 	spinlock_t		spi_lock;
@@ -81,9 +85,7 @@ baldev_read(struct file *filp, char __user *buf, size_t count, loff_t *f_pos)
 {
 	ssize_t			status = 0;
 
-	int i;
-
-	if(bal.HalType == 0x02)
+	if(bal.HalType == BAL_HAL_HW_PN5180)
 	{
 		status = wait_for_busy_idle();
 
@@ -151,7 +153,7 @@ baldev_write(struct file *filp, const char __user *buf,
 		return status;
 	}
 
-	if(bal.HalType == 2)
+	if(bal.HalType == BAL_HAL_HW_PN5180)
 	{
 		status = wait_for_busy_idle();
 		
@@ -161,7 +163,7 @@ baldev_write(struct file *filp, const char __user *buf,
 	}
 	else
 	{
-		if(bal.MultiRegRW == 4 && bal.HalType == 1/*RC663*/ )
+		if(bal.MultiRegRW == 1 && bal.HalType == BAL_HAL_HW_RC663)
 		{
 			while( pos < count )
 			{
@@ -237,24 +239,9 @@ static long
 baldev_ioctl(struct file *filp, unsigned int cmd, unsigned long arg)
 {
 	//printk(KERN_ERR "%s : %d fp=%ld cmd=%ld arg=%lx\n", __FUNCTION__, __LINE__, (unsigned long int)filp, cmd, arg);
-	printk(KERN_ERR "my ioctl\n");
+	printk(KERN_ERR "my ioctl - cmd: %d - arg: %lu\n", cmd, arg);
 
 	int status = 0; //-EINVAL;
-
-	//if (cmd == BAL_IOC_BUSY_PIN) {
-	//	if (gpio_is_valid(arg)) {
-	//		status = gpio_request(arg, "BUSY pin");
-	//		if (!status) {
-	//			dev_info(&bal.spi->dev, "Setting BUSY pin to %d\n", (unsigned int)arg);
-	//			gpio_free(bal.busy_pin);
-	//				bal.busy_pin = (unsigned int)arg;
-	//			gpio_direction_input(bal.busy_pin);
-	//		}
-	//	}
-	//
-	//}
-	
-	//dev_info(&bal.spi->dev, "%s : %d fp=%ld cmd=%ld arg=%lx\n", __FUNCTION__, __LINE__, (unsigned long int)filp, cmd, arg);
 	
 	switch (cmd) {
 		case BAL_IOC_BUSY_PIN:
@@ -273,24 +260,24 @@ baldev_ioctl(struct file *filp, unsigned int cmd, unsigned long arg)
 			//dev_info(&bal.spi->dev, "BAL_IOC_BUSY_PIN\n");
 			printk(KERN_ERR "busy pin\n");
 			break;
-		case 1:
-		case 2:
-			printk(KERN_ERR "uneffective option\n");
-			break;
+		//case 1:
+		//case 2:
+		//	printk(KERN_ERR "uneffective option\n");
+		//	break;
 		case BAL_IOC_HAL_HW_TYPE:
 			bal.HalType = arg;
 			status = 0;
 			//dev_info(&bal.spi->dev, "BAL_IOC_HAL_HW_TYPE - %d - %d\n", cmd, (unsigned int)arg);
-			printk(KERN_INFO "HAL_HW_type %s - %d %u\n", __FUNCTION__, __LINE__, arg);
+			printk(KERN_INFO "HAL_HW_type %s - %u %lu\n", __FUNCTION__, __LINE__, arg);
 			break;
 		case BAL_IOC_RW_MULTI_REG:
 			bal.MultiRegRW = arg;
 			status = 0;
 			//dev_info(&bal.spi->dev, "BAL_IOC_RW_MULTI_REG - %d - %d\n", cmd, (unsigned int)arg);
-			printk(KERN_INFO "multiREG %s - %d  %u\n", __FUNCTION__, __LINE__, arg);
+			printk(KERN_INFO "multiREG %s - %u  %lu\n", __FUNCTION__, __LINE__, arg);
 			break;
 		default:
-			printk(KERN_ERR "NO option - default\n");
+			printk(KERN_ERR "cmd: %d NO option - default\n", cmd);
 			break;
 	}
 

--- a/bal/bal.c
+++ b/bal/bal.c
@@ -82,9 +82,6 @@ baldev_read(struct file *filp, char __user *buf, size_t count, loff_t *f_pos)
 {
 	ssize_t			status = 0;
 
-	int i;
-	//struct spi_transfer xfers;
-	
 	if(bal.HalType == 0x02)
 	{
 		status = wait_for_busy_idle();
@@ -167,7 +164,14 @@ baldev_write(struct file *filp, const char __user *buf,
 		//}
 	}
 	else
-		status = spi_write(bal.spi, bal.buffer, count);
+	{
+		bal.xfers.tx_buf = bal.buffer;
+		bal.xfers.rx_buf = bal.buffer;//rxBuffer;
+		bal.xfers.len = count;
+
+		//status = spi_write(bal.spi, bal.buffer, count);
+		status = spi_sync_transfer (bal.spi, &(bal.xfers), 1);
+	}
 		
 	if (status < 0)
 		return status;

--- a/bal/bal.c
+++ b/bal/bal.c
@@ -248,7 +248,8 @@ baldev_read(struct file *filp, char __user *buf, size_t count, loff_t *f_pos)
   xfers.tx_buf = bal.buffer;
   xfers.rx_buf = bal.rxBuffer;
   xfers.len = count;
-  //xfers.dma_addr_t tx_dma;
+
+  xfers.rx_dma = bal.buffer;
   xfers.rx_dma = bal.rxBuffer;
   //struct sg_table tx_sg;
   //struct sg_table rx_sg;
@@ -258,17 +259,20 @@ baldev_read(struct file *filp, char __user *buf, size_t count, loff_t *f_pos)
 
   xfers.bits_per_word = 8;
   xfers.delay_usecs = 0;
-  //u32 speed_hz;
+  xfers.speed_hz = bal.spi->max_speed_hz;
   //struct list_head transfer_list;
 //}; 
 
   uint16_t flags = bal.spi->master->flags;
-  printk(KERN_ERR "master flags = %04X\n", bal.spi->master->flags);
-  printk(KERN_ERR "mode flags = %04X\n", bal.spi->mode);
+  //printk(KERN_ERR "master flags = %04X\n", bal.spi->master->flags);
+  //printk(KERN_ERR "mode flags = %04X\n", bal.spi->mode);
+  printk(KERN_ERR "speed_hz = %d Hz\n", xfers.speed_hz);
+  
+  printk(KERN_ERR "speed_hz spidev= %d Hz\n", bal.spi->max_speed_hz);
 
 
-  status = __spi_validate(bal.spi, &xfers);
-  printk(KERN_ERR "status = %d\n", status);
+  //status = __spi_validate(bal.spi, &xfers);
+  //printk(KERN_ERR "status = %d\n", status);
 
 	if(bal.HalType == 0x02)
 	{
@@ -282,10 +286,10 @@ baldev_read(struct file *filp, char __user *buf, size_t count, loff_t *f_pos)
 	}
 	else
 	{
-		for(i = 0; i < count; i++) {
-			printk(KERN_ERR "before READ buffer[%d] = %d", i, bal.buffer[i]);
-			printk(KERN_ERR "before READ rxBuffer[%d] = %d", i, bal.rxBuffer[i]);
-		}
+		//for(i = 0; i < count; i++) {
+		//	printk(KERN_ERR "before READ buffer[%d] = %d", i, bal.buffer[i]);
+		//	printk(KERN_ERR "before READ rxBuffer[%d] = %d", i, bal.rxBuffer[i]);
+		//}
 		
 		//for(i = 0; i < count; i++)
 		//{
@@ -295,17 +299,17 @@ baldev_read(struct file *filp, char __user *buf, size_t count, loff_t *f_pos)
 		//}
 		//bal.buffer[0] = 0x00; // reader expets the first byte in the reply buffer 00h
 
-		//status = spi_sync_transfer (bal.spi, &xfers, 1);
+		status = spi_sync_transfer (bal.spi, &xfers, 1);
 
 		if(status != 0){
 			printk(KERN_ERR "status = %d = %04X\n", status, status);
 			return status;
 		}
 
-		for(i = 0; i < count; i++) {
-			printk(KERN_ERR "after READ buffer[%d] = %d", i, bal.buffer[i]);
-			printk(KERN_ERR "after READ rxBuffer[%d] = %d", i, bal.rxBuffer[i]);
-		}
+		//for(i = 0; i < count; i++) {
+		//	printk(KERN_ERR "after READ buffer[%d] = %d", i, bal.buffer[i]);
+		//	printk(KERN_ERR "after READ rxBuffer[%d] = %d", i, bal.rxBuffer[i]);
+		//}
 	
 		result = 0;
 	//if (copy_to_user(buf, &result, 1))

--- a/bal/bal.c
+++ b/bal/bal.c
@@ -123,36 +123,35 @@ baldev_read(struct file *filp, char __user *buf, size_t count, loff_t *f_pos)
 	{
 		for(i = 0; i < count; i++) {
 			printk(KERN_ERR "before READ buffer[%d] = %d", i, bal.buffer[i]);
-			printk(KERN_ERR "before READ rxBuffer[%d] = %d", i, bal.rxBuffer[i]);
+			//printk(KERN_ERR "before READ rxBuffer[%d] = %d", i, bal.rxBuffer[i]);
 		}
 		
-		//for(i = 0; i < count; i++)
-		//{
+		for(i = 0; i < count; i++)
+		{
 			//status = spi_write_then_read(bal.spi, bal.buffer, count,  bal.buffer, count);
-		//	result = spi_w8r8(bal.spi, bal.buffer[i]);						
-		//	bal.buffer[i] = (uint8_t)result;
-		//}
-		//bal.buffer[0] = 0x00; // reader expets the first byte in the reply buffer 00h
+			result = spi_w8r8(bal.spi, bal.buffer[i]);						
+			bal.buffer[i] = (uint8_t)result;
+			printk(KERN_ERR "result = %d\n", result);
+		}
 
 		//status = spi_sync_transfer (bal.spi, &xfers, 1);
-
-		if(status != 0){
-			printk(KERN_ERR "status = %d = %04X\n", status, status);
-			return status;
-		}
+		//if(status != 0){
+		//	printk(KERN_ERR "status = %d = %04X\n", status, status);
+		//	return status;
+		//}
 
 		for(i = 0; i < count; i++) {
 			printk(KERN_ERR "after READ buffer[%d] = %d", i, bal.buffer[i]);
-			printk(KERN_ERR "after READ rxBuffer[%d] = %d", i, bal.rxBuffer[i]);
+			//printk(KERN_ERR "after READ rxBuffer[%d] = %d", i, bal.rxBuffer[i]);
 		}
 	
 		result = 0;
-	//if (copy_to_user(buf, &result, 1))
-	//	return -EFAULT;
-	//if (copy_to_user(buf+1, bal.buffer, count-1))
-	//	return -EFAULT;
-	if (copy_to_user(buf, bal.rxBuffer, count))
+	if (copy_to_user(buf, &result, 1))
 		return -EFAULT;
+	if (copy_to_user(buf+1, bal.buffer, count-1))
+		return -EFAULT;
+	//if (copy_to_user(buf, bal.rxBuffer, count))
+	//	return -EFAULT;
 	
 	}
 	return count;

--- a/bal/bal.c
+++ b/bal/bal.c
@@ -74,6 +74,163 @@ wait_for_busy_idle(void)
 	return 0;
 }
 
+ static int __spi_validate_bits_per_word(struct spi_master *master, u8 bits_per_word)
+ {
+         if (master->bits_per_word_mask) {
+                 /* Only 32 bits fit in the mask */
+                 if (bits_per_word > 32)
+                         return printk(KERN_ERR "!!!VALIDATION_ERROR!!! - %d\n", __LINE__);//-EINVAL;
+                 if (!(master->bits_per_word_mask &
+                                 SPI_BPW_MASK(bits_per_word)))
+                         return printk(KERN_ERR "!!!VALIDATION_ERROR!!! - %d\n", __LINE__);//-EINVAL;
+         }
+ 
+        return 0;
+ }
+
+static int __spi_validate(struct spi_device *spi, struct spi_transfer *transfer)
+{
+         struct spi_master *master = spi->master;
+         struct spi_transfer *xfer = transfer;
+         int w_size;
+
+		 printk("%s\n", __FUNCTION__);
+ 
+         //if (list_empty(&message->transfers))
+         //        return printk("!!!VALIDATION_ERROR!!! - %d\n", __LINE__);//-EINVAL;
+ 
+         /* Half-duplex links include original MicroWire, and ones with
+          * only one data pin like SPI_3WIRE (switches direction) or where
+          * either MOSI or MISO is missing.  They can also be caused by
+          * software limitations.
+          */
+         if ((master->flags & SPI_MASTER_HALF_DUPLEX)
+                         || (spi->mode & SPI_3WIRE)) {
+                 unsigned flags = master->flags;
+ 
+                 /*list_for_each_entry(xfer, &message->transfers, transfer_list)*/ {
+                         if (xfer->rx_buf && xfer->tx_buf)
+						 {
+							 printk(KERN_ERR "!!!VALIDATION_ERROR!!! - %d\n", __LINE__);//
+							 return -EINVAL;
+						 }                                 
+                         if ((flags & SPI_MASTER_NO_TX) && xfer->tx_buf)
+                         {
+							 printk(KERN_ERR "!!!VALIDATION_ERROR!!! - %d\n", __LINE__);//
+							 return -EINVAL;
+						 }
+                         if ((flags & SPI_MASTER_NO_RX) && xfer->rx_buf)
+                         {
+							 printk(KERN_ERR "!!!VALIDATION_ERROR!!! - %d\n", __LINE__);//
+							 return -EINVAL;
+						 }
+                 }
+         }
+ 
+         /**
+          * Set transfer bits_per_word and max speed as spi device default if
+          * it is not set for this transfer.
+          * Set transfer tx_nbits and rx_nbits as single transfer default
+          * (SPI_NBITS_SINGLE) if it is not set for this transfer.
+          */
+         //message->frame_length = 0;
+         {
+                 //message->frame_length += xfer->len;
+                 if (!xfer->bits_per_word)
+                         xfer->bits_per_word = spi->bits_per_word;
+ 
+                 if (!xfer->speed_hz)
+                         xfer->speed_hz = spi->max_speed_hz;
+                 if (!xfer->speed_hz)
+                         xfer->speed_hz = master->max_speed_hz;
+ 
+                 if (master->max_speed_hz &&
+                     xfer->speed_hz > master->max_speed_hz)
+                         xfer->speed_hz = master->max_speed_hz;
+ 
+                 if (__spi_validate_bits_per_word(master, xfer->bits_per_word))
+                         return -EINVAL;
+ 
+                 /*
+                  * SPI transfer length should be multiple of SPI word size
+                  * where SPI word size should be power-of-two multiple
+                  */
+                 if (xfer->bits_per_word <= 8)
+                         w_size = 1;
+                 else if (xfer->bits_per_word <= 16)
+                         w_size = 2;
+                 else
+                         w_size = 4;
+ 
+                 /* No partial transfers accepted */
+                 if (xfer->len % w_size)
+                         return -EINVAL;
+ 
+                 if (xfer->speed_hz && master->min_speed_hz &&
+                     xfer->speed_hz < master->min_speed_hz)
+				 {
+                         printk(KERN_ERR "!!!VALIDATION_ERROR!!! - %d\n", __LINE__);
+						 return -EINVAL;
+				 }
+ 
+                 if (xfer->tx_buf && !xfer->tx_nbits)
+                         xfer->tx_nbits = SPI_NBITS_SINGLE;
+                 if (xfer->rx_buf && !xfer->rx_nbits)
+                         xfer->rx_nbits = SPI_NBITS_SINGLE;
+                 /* check transfer tx/rx_nbits:
+                  * 1. check the value matches one of single, dual and quad
+                  * 2. check tx/rx_nbits match the mode in spi_device
+                  */
+                 if (xfer->tx_buf) {
+                         if (xfer->tx_nbits != SPI_NBITS_SINGLE &&
+                                 xfer->tx_nbits != SPI_NBITS_DUAL &&
+                                 xfer->tx_nbits != SPI_NBITS_QUAD)
+                                  {
+									printk(KERN_ERR "!!!VALIDATION_ERROR!!! - %d\n", __LINE__);
+									return -EINVAL;
+								}
+                         if ((xfer->tx_nbits == SPI_NBITS_DUAL) &&
+                                 !(spi->mode & (SPI_TX_DUAL | SPI_TX_QUAD)))
+                                  {
+									printk(KERN_ERR "!!!VALIDATION_ERROR!!! - %d\n", __LINE__);
+									 return -EINVAL;
+								}
+                         if ((xfer->tx_nbits == SPI_NBITS_QUAD) &&
+                                 !(spi->mode & SPI_TX_QUAD))
+                                  {
+									printk(KERN_ERR "!!!VALIDATION_ERROR!!! - %d\n", __LINE__);
+									 return -EINVAL;
+									}
+                 }
+                 /* check transfer rx_nbits */
+                 if (xfer->rx_buf) {
+                         if (xfer->rx_nbits != SPI_NBITS_SINGLE &&
+                                 xfer->rx_nbits != SPI_NBITS_DUAL &&
+                                 xfer->rx_nbits != SPI_NBITS_QUAD)
+                                  {
+									printk(KERN_ERR "!!!VALIDATION_ERROR!!! - %d\n", __LINE__);
+									return -EINVAL;
+									}
+                         if ((xfer->rx_nbits == SPI_NBITS_DUAL) &&
+                                 !(spi->mode & (SPI_RX_DUAL | SPI_RX_QUAD)))
+                                  {
+									printk(KERN_ERR "!!!VALIDATION_ERROR!!! - %d\n", __LINE__);
+									return -EINVAL;
+									}
+                         if ((xfer->rx_nbits == SPI_NBITS_QUAD) &&
+                                 !(spi->mode & SPI_RX_QUAD))
+                                  {
+										printk(KERN_ERR "!!!VALIDATION_ERROR!!! - %d\n", __LINE__);
+										return -EINVAL;
+									}
+                 }
+         }
+ 
+         //message->status = -EINPROGRESS;
+ 
+         return 0;
+}
+
 static ssize_t
 baldev_read(struct file *filp, char __user *buf, size_t count, loff_t *f_pos)
 {
@@ -109,6 +266,10 @@ baldev_read(struct file *filp, char __user *buf, size_t count, loff_t *f_pos)
   printk(KERN_ERR "master flags = %04X\n", bal.spi->master->flags);
   printk(KERN_ERR "mode flags = %04X\n", bal.spi->mode);
 
+
+  status = __spi_validate(bal.spi, &xfers);
+  printk(KERN_ERR "status = %d\n", status);
+
 	if(bal.HalType == 0x02)
 	{
 		status = wait_for_busy_idle();
@@ -123,35 +284,36 @@ baldev_read(struct file *filp, char __user *buf, size_t count, loff_t *f_pos)
 	{
 		for(i = 0; i < count; i++) {
 			printk(KERN_ERR "before READ buffer[%d] = %d", i, bal.buffer[i]);
-			//printk(KERN_ERR "before READ rxBuffer[%d] = %d", i, bal.rxBuffer[i]);
+			printk(KERN_ERR "before READ rxBuffer[%d] = %d", i, bal.rxBuffer[i]);
 		}
 		
-		for(i = 0; i < count; i++)
-		{
+		//for(i = 0; i < count; i++)
+		//{
 			//status = spi_write_then_read(bal.spi, bal.buffer, count,  bal.buffer, count);
-			result = spi_w8r8(bal.spi, bal.buffer[i]);						
-			bal.buffer[i] = (uint8_t)result;
-			printk(KERN_ERR "result = %d\n", result);
-		}
+		//	result = spi_w8r8(bal.spi, bal.buffer[i]);						
+		//	bal.buffer[i] = (uint8_t)result;
+		//}
+		//bal.buffer[0] = 0x00; // reader expets the first byte in the reply buffer 00h
 
 		//status = spi_sync_transfer (bal.spi, &xfers, 1);
-		//if(status != 0){
-		//	printk(KERN_ERR "status = %d = %04X\n", status, status);
-		//	return status;
-		//}
+
+		if(status != 0){
+			printk(KERN_ERR "status = %d = %04X\n", status, status);
+			return status;
+		}
 
 		for(i = 0; i < count; i++) {
 			printk(KERN_ERR "after READ buffer[%d] = %d", i, bal.buffer[i]);
-			//printk(KERN_ERR "after READ rxBuffer[%d] = %d", i, bal.rxBuffer[i]);
+			printk(KERN_ERR "after READ rxBuffer[%d] = %d", i, bal.rxBuffer[i]);
 		}
 	
 		result = 0;
-	if (copy_to_user(buf, &result, 1))
-		return -EFAULT;
-	if (copy_to_user(buf+1, bal.buffer, count-1))
-		return -EFAULT;
-	//if (copy_to_user(buf, bal.rxBuffer, count))
+	//if (copy_to_user(buf, &result, 1))
 	//	return -EFAULT;
+	//if (copy_to_user(buf+1, bal.buffer, count-1))
+	//	return -EFAULT;
+	if (copy_to_user(buf, bal.rxBuffer, count))
+		return -EFAULT;
 	
 	}
 	return count;


### PR DESCRIPTION
Christian, please do a review of the code.
I tested the module with the nine Examples and it worked.

These is an issue with the baldev_ioctl. It does not accept 2 as second (cmd) argument. Can you look at it?

Another issue is, I do not know how to #include symbols  like PHBAL_REG_CONFIG_HAL_HW_TYPE from phbalReg.h to the BAL sources. So for now there are hardcoded numbers in the baldev_ioctl().

Pavol
